### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.8.8组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.8.8</version>
+      <version>2.9.10.8</version>
     </dependency>
 
     <dependency>
@@ -94,8 +94,7 @@
 
   </dependencies>
 
-</project>
-        <!--
+</project><!--
           Licensed to the Apache Software Foundation (ASF) under one
           or more contributor license agreements.  See the NOTICE file
           distributed with this work for additional information
@@ -112,5 +111,4 @@
           KIND, either express or implied.  See the License for the
           specific language governing permissions and limitations
           under the License.
-        -->
-        <!-- $Id: pom.xml 642118 2008-03-28 08:04:16Z reinhard $ -->
+        --><!-- $Id: pom.xml 642118 2008-03-28 08:04:16Z reinhard $ -->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 反序列化漏洞(JtaTransactionConfig gadget绕过)
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.8.8
漏洞编号：CVE-2020-9547
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML jackson-databind 2.9.10.4之前的2.x版本中存在代码问题漏洞。攻击者可借助特制的请求利用该漏洞在系统上执行任意代码。
影响范围：[2.8.0, 2.8.11.6)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.vote:vote@1.0-SNAPSHOT->com.fasterxml.jackson.core:jackson-databind@2.8.8
```
另外我运行这个项目时，IDE的安全插件提示还有83个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pc5178